### PR TITLE
Method that makes it possbile to use parameters in translation strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 .DS_Store
+example/node_modules

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ var myComp = Vue.extend({
 	        {{ t('Hello World') }}
 	        <span v-translate>How are you?</span>
 	    </div>`,
-    
+
     mounted() {
         // Define what language you want to use.
         // This can be called in something like a header with a language selector menu
@@ -46,9 +46,9 @@ var myComp = Vue.extend({
 
 var vm = new Vue({
 	el: '#app',
-	
+
 	components: {myComp},
-	
+
 	template: `<div>
 	    <my-comp></my-comp>
 	</div>`
@@ -117,6 +117,25 @@ You can listen to custom events emitted by the `$translate` property:
 this.$translate.$on('language:changed', language => {
 	console.log('The user choose '+language);
 })
+```
+
+### Parameters
+
+You can use the method `textWithParams` if you would like to insert parameters in your translation strings.
+
+```js
+this.$translate.textWithParams('translation.string', {
+  keyA: 'Glenn',
+  keyB: 'John'
+})
+
+{{ tWithParams('translation.string', { keyA: 'Glenn', keyB: 'John' }) }}
+
+// In locales.js
+'translation.string': 'My name is %keyA%. My brother is named %keyB%.'
+
+// Result
+'My name is Glenn. My brother is named John.'
 ```
 
 ##### language:init

--- a/src/vue-translate.js
+++ b/src/vue-translate.js
@@ -73,6 +73,22 @@ const VueTranslate = {
                         }
 
                         return this.locale[t];
+                    },
+
+                    textWithParams(t, params = null) {
+                        if (!this.locale || !this.locale[t]) {
+                            return t;
+                        }
+
+                        if (!this.params || this.params === null || typeof this.params === 'undefined') {
+                            return t;
+                        }
+
+                        Object.keys(params).forEach((key) => {
+                            t = t.replace(`%${key}%`, params[key]);
+                        });
+
+                        return t;
                     }
                 }
             });
@@ -90,6 +106,10 @@ const VueTranslate = {
                 // An alias for the .$translate.text method
                 t(t) {
                     return this.$translate.text(t);
+                },
+
+                tWithParams(t, params) {
+                    return this.$translate.text(t, params);
                 }
             },
 


### PR DESCRIPTION
This PR will implement a new method that can be used to use parameters in your translation strings.

Often I have to use a certain variable, a name, a number or something like that in my translation strings. In the current version of the package, a simple `Hello Glenn!` would look something like this:

```javascript
const greeting = `${this.$translate.text('greeting')} Glenn!`

// Even 'worse'
<p>{{ t('greeting') }} Glenn!</p>
```

This package is really easy to use, so I use it all the time but because of that I have the problem above also all the time 🤪. Because of that, I've created a method that will solve that:

```js
this.$translate.textWithParams('translation.string', {
  keyA: 'Glenn',
  keyB: 'John'
})

// In locales.js
'translation.string': 'My name is %keyA%. My brother is named %keyB%.'

// Result
'My name is Glenn. My brother is named John.'
```

Please let me know what you think, I would appreciate it if this get's merged. One sidenot, I couldn't find any notes on building the code. What steps do I need to take to re-compile the source code to a new build?